### PR TITLE
feat: support locating element inside an iframe

### DIFF
--- a/src/ivya.ts
+++ b/src/ivya.ts
@@ -104,7 +104,7 @@ export class Ivya {
     this._engines.set('css', this._createCSSEngine())
     this._engines.set('nth', { queryAll: () => [] })
     this._engines.set('visible', this._createVisibleEngine())
-    this._engines.set('internal:control', { queryAll: () => [] })
+    this._engines.set('internal:control', this._createControlEngine())
     this._engines.set('internal:has', this._createHasEngine())
     this._engines.set('internal:has-not', this._createHasNotEngine())
     this._engines.set('internal:and', { queryAll: () => [] })
@@ -630,6 +630,17 @@ export class Ivya {
       return isElementVisible(root as Element) === Boolean(body)
         ? [root as Element]
         : []
+    }
+    return { queryAll }
+  }
+
+  private _createControlEngine(): SelectorEngine {
+    const queryAll = (root: SelectorRoot, body: string) => {
+      if (body === 'enter-frame' && root instanceof HTMLIFrameElement) {
+        const doc = root.contentDocument?.documentElement
+        return doc ? [doc] : []
+      }
+      return []
     }
     return { queryAll }
   }

--- a/test/iframe.test.ts
+++ b/test/iframe.test.ts
@@ -1,0 +1,24 @@
+import { getByTestIdSelector, Ivya } from '../src'
+import { expect, test } from 'vitest'
+
+test('locates element inside iframe', async () => {
+  const iframe = document.createElement('iframe')
+  iframe.setAttribute('data-testid', 'test-iframe')
+  iframe.srcdoc = '<body><button>Click me</button>'
+  document.body.appendChild(iframe)
+
+  const ivya = Ivya.create({
+    browser: 'chromium',
+  })
+
+  // wait for iframe to load
+  await new Promise((resolve) => (iframe.onload = resolve))
+
+  const iframeSelector = getByTestIdSelector('data-testid', 'test-iframe')
+  expect(ivya.queryLocatorSelector(iframeSelector)).toBe(iframe)
+
+  const button = iframe.contentDocument!.querySelector('button')
+  expect(
+    ivya.queryLocatorSelector('iframe >> internal:control=enter-frame >> button')
+  ).toBe(button)
+})


### PR DESCRIPTION
Related to https://github.com/vitest-dev/vitest/issues/6966 and https://github.com/vitest-dev/vitest/pull/8016.

Retrieves the iframe's `contentDocument` when querying locator.
`contentDocument` is only available on `same-origin` urls.

I noticed that on the vitest test, the iframe doesn't load Immediately.
`expect.element` works. Not sure if there is a way to prevent this?

```js
test('locates an iframe', async () => {
  const iframe = document.createElement('iframe')
  iframe.setAttribute('data-testid', 'iframe')
  iframe.srcdoc = `<div onclick="console.log">Hello World!</div>`
  document.body.append(iframe)

  const frame = page.frameLocator(
    page.getByTestId('iframe'),
  )

  await expect.element(frame.getByText('Hello World')).toBeTruthy()
})

```