### PR TITLE
fix: fix aria role generation of `input[type="file"]`

### DIFF
--- a/src/roleUtils.ts
+++ b/src/roleUtils.ts
@@ -186,6 +186,12 @@ const kImplicitRoleByTagName: {
     if (type === 'hidden') {
       return ''
     }
+    // File inputs do not have a role by the spec: https://www.w3.org/TR/html-aam-1.0/#el-input-file.
+    // However, there are open issues about fixing it: https://github.com/w3c/aria/issues/1926.
+    // All browsers report it as a button, and it is rendered as a button, so we do "button".
+    if (type === 'file') {
+      return 'button'
+    }
     return (
       {
         button: 'button',

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -20,3 +20,25 @@ test('works correctly', () => {
     ivya.queryLocatorSelector(`css=body >> ${buttonSelector}`)
   ).toBe(button)
 })
+
+test('file input', () => {
+  const input = document.createElement('input')
+  input.type = 'file'
+  document.body.appendChild(input)
+
+  const ivya = Ivya.create({
+    browser: 'chromium',
+  })
+
+  expect(ivya.generateSelectorSimple(input)).toMatchInlineSnapshot(
+    `"input[type="file"]"`
+  )
+
+  input.id = 'test1'
+  expect(ivya.generateSelectorSimple(input)).toMatchInlineSnapshot(`"#test1"`)
+
+  input.dataset.testid = 'test2'
+  expect(ivya.generateSelectorSimple(input)).toMatchInlineSnapshot(
+    `"internal:testid=[data-testid="test2"s]"`
+  )
+})


### PR DESCRIPTION
- Closes https://github.com/vitest-dev/vitest/issues/8646

Currently it generates `role=textbox` for `input[type="file"]`, but Chrome's accessibility tree query doesn't support that anymore. This causes browser mode selector to not be able to find element. Some references on Playwright side:
- https://github.com/microsoft/playwright/issues/35499
- https://github.com/microsoft/playwright/pull/35514