### PR TITLE
fix: fix `/children` directive on root fragment

### DIFF
--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -120,7 +120,15 @@ export function matchAriaTree(
   // decides pass/fail (via matchesNode); mergeNode below it is purely
   // rendering. Wrapping in single-element lists ensures that contract
   // holds from the top level down.
-  const result = mergeChildLists([root], [template], '')
+  const result = mergeChildLists(
+    [root],
+    [template],
+    '',
+    // Propagate container mode on root fragments
+    template.kind === 'role' && template.role === 'fragment'
+      ? template.containerMode
+      : undefined
+  )
 
   return {
     pass: result.pass,

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -120,9 +120,18 @@ export function matchAriaTree(
   // decides pass/fail (via matchesNode); mergeNode below it is purely
   // rendering. Wrapping in single-element lists ensures that contract
   // holds from the top level down.
+
+  const children =
+    typeof root !== 'string' && root.role === 'fragment' ? root.children : [root]
+
+  const templates =
+    template.kind === 'role' && template.role === 'fragment'
+      ? template.children || []
+      : [template]
+
   const result = mergeChildLists(
-    [root],
-    [template],
+    children,
+    templates,
     '',
     // Propagate container mode on root fragments
     template.kind === 'role' && template.role === 'fragment'
@@ -252,14 +261,6 @@ function mergeChildLists(
   indent: string,
   containerMode?: ContainerMode
 ): MergeResult {
-  // fragment = its children (a fragment has no semantics of its own)
-  children = children.flatMap((c) =>
-    typeof c !== 'string' && c.role === 'fragment' ? c.children : [c]
-  )
-  templates = templates.flatMap((t) =>
-    t.kind === 'role' && t.role === 'fragment' ? t.children || [] : [t]
-  )
-
   if (containerMode === 'equal' || containerMode === 'deep-equal') {
     return mergeChildListsEqual(
       children,

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4293,6 +4293,49 @@ describe('/children directive', () => {
     `)
   })
 
+  test('/children: deep-equal at root — extra children rejected', () => {
+    const html = `
+      <ul>
+        <li>A</li>
+        <li>B</li>
+        <li>C</li>
+      </ul>
+    `
+    expect(
+      match(
+        html,
+        `
+        - /children: deep-equal
+        - list:
+          - listitem: A
+          - listitem: C
+      `,
+        { assertInvariant: false }
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "actual": "
+      - list:
+        - listitem: A
+        - listitem: B
+        - listitem: C
+      ",
+        "actualResolved": "
+      - list:
+        - listitem: A
+        - listitem: B
+        - listitem: C
+      ",
+        "expected": "
+      - list:
+        - listitem: A
+        - listitem: C
+      ",
+        "pass": false,
+      }
+    `)
+  })
+
   test('/children: deep-equal — propagates equal to descendants', () => {
     // Inner list has 2 items but template only mentions 1.
     // With contain this would pass; deep-equal rejects it.

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4336,6 +4336,71 @@ describe('/children directive', () => {
     `)
   })
 
+
+  test('/children: deep-equal only at root', () => {
+    const html = ``
+    expect(
+      match(
+        html,
+        `
+        - /children: deep-equal
+      `,
+        { assertInvariant: false }
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "actual": "
+
+      ",
+        "actualResolved": "
+
+      ",
+        "expected": "
+
+      ",
+        "pass": true,
+      }
+    `)
+  })
+
+  test('/children: deep-equal only at root — extra children rejected', () => {
+    const html = `
+      <ul>
+        <li>A</li>
+        <li>B</li>
+        <li>C</li>
+      </ul>
+    `
+    expect(
+      match(
+        html,
+        `
+        - /children: deep-equal
+      `,
+        { assertInvariant: false }
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "actual": "
+      - list:
+        - listitem: A
+        - listitem: B
+        - listitem: C
+      ",
+        "actualResolved": "
+      - list:
+        - listitem: A
+        - listitem: B
+        - listitem: C
+      ",
+        "expected": "
+
+      ",
+        "pass": false,
+      }
+    `)
+  })
+
   test('/children: deep-equal — propagates equal to descendants', () => {
     // Inner list has 2 items but template only mentions 1.
     // With contain this would pass; deep-equal rejects it.

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4336,7 +4336,6 @@ describe('/children directive', () => {
     `)
   })
 
-
   test('/children: deep-equal only at root', () => {
     const html = ``
     expect(


### PR DESCRIPTION
I wish to write a matcher that has the full capabilities of `matchAriaTree`, but defaults to rejecting extra children on the root node.

However, adding `- /children: deep-equal` to the root `fragment` appears not to work, as demonstrated in this failing test.

Raised as a PR because...no issues?

edit: now I see issues. whoops!

edit edit: now with a possible fix