### PR TITLE
fix: support empty template in parseAriaTemplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "prepare": "vp config",
     "dev": "vp pack --watch --sourcemap",
     "build": "vp pack",
+    "lint": "vp check --no-lint",
+    "lint-fix": "vp check --no-lint --fix",
     "typecheck": "tsc -b",
     "test-chrome": "vitest --project='*chromium*'",
     "test-unit": "vitest --project=unit",

--- a/src/aria/folk/isomorphic/ariaSnapshot.ts
+++ b/src/aria/folk/isomorphic/ariaSnapshot.ts
@@ -382,15 +382,13 @@ export function parseAriaSnapshot(
   yamlDoc.errors.forEach(addError)
   if (errors.length) return { errors, fragment }
 
+  if (!yamlDoc.contents) {
+    return { fragment, errors: [] }
+  }
   if (!(yamlDoc.contents instanceof yaml.YAMLSeq)) {
     errors.push({
       message: 'Aria snapshot must be a YAML sequence, elements starting with " -"',
-      range: yamlDoc.contents
-        ? convertRange(yamlDoc.contents!.range)
-        : [
-            { line: 0, col: 0 },
-            { line: 0, col: 0 },
-          ],
+      range: convertRange(yamlDoc.contents.range),
     })
   }
   if (errors.length) return { errors, fragment }

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -2488,6 +2488,20 @@ describe('parseAriaTemplate', () => {
     expect(t).toEqual({ kind: 'role', role: 'fragment' })
   })
 
+  test('non sequence', () => {
+    expect(() =>
+      parseAriaTemplate(`hello: world`)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Aria snapshot must be a YAML sequence, elements starting with " -"]`
+    )
+    expect(() => parseAriaTemplate(`hello`)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Unexpected scalar at node end]`
+    )
+    expect(() => parseAriaTemplate(`1234`)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Unexpected scalar at node end]`
+    )
+  })
+
   test('throws on invalid role entry', () => {
     expect(() => parseAriaTemplate('- !@#')).toThrowErrorMatchingInlineSnapshot(
       `

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -240,6 +240,19 @@ describe('basic', () => {
     `)
   })
 
+  test('empty aria tree', () => {
+    const result = runPipeline('<div aria-hidden="true">Hidden</div>')
+    expect(result.snapshot).toMatchInlineSnapshot(`
+      {
+        "captured": [],
+        "pass": true,
+        "rendered": "
+
+      ",
+      }
+    `)
+  })
+
   test('checkbox states', () => {
     const result = runPipeline(`
       <div role="checkbox" aria-checked="true" aria-label="A"></div>
@@ -3690,23 +3703,6 @@ describe('matchAriaTree', () => {
       {
         "actual": "
       - paragraph: anything
-      ",
-        "actualResolved": "
-
-      ",
-        "expected": "
-
-      ",
-        "pass": true,
-      }
-    `)
-  })
-
-  test('empty aria tree', () => {
-    expect(match('<div aria-hidden="true">Hidden</div>', '')).toMatchInlineSnapshot(`
-      {
-        "actual": "
-
       ",
         "actualResolved": "
 

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -2471,10 +2471,8 @@ describe('parseAriaTemplate', () => {
   })
 
   test('empty input', () => {
-    const t = () => parseAriaTemplate(``)
-    expect(t).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Aria snapshot must be a YAML sequence, elements starting with " -"]`
-    )
+    const t = parseAriaTemplate(``)
+    expect(t).toEqual({ kind: 'role', role: 'fragment' })
   })
 
   test('throws on invalid role entry', () => {

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -3686,9 +3686,37 @@ describe('matchAriaTree', () => {
   // and containsList(anything, []) returns true (vacuous truth).
   // Same semantics as Playwright — "I don't care what's here."
   test('empty template', () => {
-    expect(() => match('<p>anything</p>', '')).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Aria snapshot must be a YAML sequence, elements starting with " -"]`
-    )
+    expect(match('<p>anything</p>', '')).toMatchInlineSnapshot(`
+      {
+        "actual": "
+      - paragraph: anything
+      ",
+        "actualResolved": "
+
+      ",
+        "expected": "
+
+      ",
+        "pass": true,
+      }
+    `)
+  })
+
+  test('empty aria tree', () => {
+    expect(match('<div aria-hidden="true">Hidden</div>', '')).toMatchInlineSnapshot(`
+      {
+        "actual": "
+
+      ",
+        "actualResolved": "
+
+      ",
+        "expected": "
+
+      ",
+        "pass": true,
+      }
+    `)
   })
 
   // -- Gap: deeply nested mismatch


### PR DESCRIPTION
Closes https://github.com/vitest-dev/ivya/issues/16

## Problem

`parseAriaTemplate('')` throws "Aria snapshot must be a YAML sequence" because
`yaml.parseDocument('')` returns `contents: null`, which is not a `YAMLSeq`.

## Fix

Add an early return for `null` contents — return an empty fragment node
`{ kind: 'role', role: 'fragment' }` with no errors. This also simplifies the
existing error path since `yamlDoc.contents` is guaranteed non-null after the
new guard, removing the ternary fallback for the range.

## Context

This unblocks the vitest-side fix for vitest-dev/vitest#10158
(vitest-dev/vitest#10188), which correctly distinguishes empty string from
undefined in domain snapshots but needs ivya to handle empty templates.

## Test

Updated the existing `empty input` test case in `test/aria.test.ts` to expect
an empty fragment instead of an error.