### PR TITLE
fix: fix scalar alone line parsing

### DIFF
--- a/src/aria/yaml.ts
+++ b/src/aria/yaml.ts
@@ -243,6 +243,7 @@ class Parser {
       return this.parseMap(line.indent)
     }
     // Single scalar
+    this.pos++
     return this.parseScalarValue(line.content, line.offset, line)
   }
 

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -2435,6 +2435,29 @@ describe('parseAriaTemplate', () => {
     `)
   })
 
+  test('nested scalar text child', () => {
+    const t = parseAriaTemplate(`
+      - button:
+          Submit
+    `)
+    expect(t).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "kind": "text",
+            "text": {
+              "normalized": "Submit",
+              "raw": "Submit",
+            },
+          },
+        ],
+        "kind": "role",
+        "name": undefined,
+        "role": "button",
+      }
+    `)
+  })
+
   test('regex text node', () => {
     const t = parseAriaTemplate('- text: /hello \\d+/')
     expect(t).toMatchInlineSnapshot(`
@@ -2495,10 +2518,10 @@ describe('parseAriaTemplate', () => {
       `[Error: Aria snapshot must be a YAML sequence, elements starting with " -"]`
     )
     expect(() => parseAriaTemplate(`hello`)).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Unexpected scalar at node end]`
+      `[Error: Aria snapshot must be a YAML sequence, elements starting with " -"]`
     )
     expect(() => parseAriaTemplate(`1234`)).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Unexpected scalar at node end]`
+      `[Error: Aria snapshot must be a YAML sequence, elements starting with " -"]`
     )
   })
 


### PR DESCRIPTION
There's an edge case where yaml parser is failed to parse. Previously parser expected the scalar to appear only as part of parent structure such as:

```yaml
- key: scalar
```

```yaml
- scalar
```

But, there was also valid cases such as:

```yaml
hello
```

```yaml
- key:
    scalar
```

These were the case where scalar lives on its line but was parse error due to parser not consuming line.