### PR TITLE
fix: fix `/children` directive on root fragment (take 2)

### DIFF
--- a/src/aria/folk/isomorphic/ariaSnapshot.ts
+++ b/src/aria/folk/isomorphic/ariaSnapshot.ts
@@ -505,8 +505,8 @@ export class KeyParser {
     this._throwError('Unterminated string')
   }
 
-  private _throwError(message: string, offset?: number): never {
-    throw new ParserError(message, offset ?? this._pos)
+  private _throwError(message: string, offset: number = this._pos): never {
+    throw new ParserError(message, offset)
   }
 
   private _readRegex(): AriaRegex {
@@ -583,13 +583,12 @@ export class KeyParser {
   _parse(): AriaTemplateRoleNode {
     this._skipWhitespace()
 
-    const roleStart = this._pos
-    const role = this._readIdentifier('role')
+    const role = this._readIdentifier('role') as AriaTemplateRoleNode['role']
+    // DIVERGENCE(playwright):
+    // we reject explicit `fragment` since that complicates matching algorithm invariant.
+    // this is only meant for internal role generated to model root templates.
     if (role === 'fragment') {
-      this._throwError(
-        'Role "fragment" is reserved for the internal root wrapper',
-        roleStart
-      )
+      this._throwError('Invalid role "fragment"')
     }
     this._skipWhitespace()
     // DIVERGENCE(playwright): upstream uses `|| ''`, which makes
@@ -598,11 +597,7 @@ export class KeyParser {
     // (falsy), causing asymmetry between matching and rendering.
     // Upstream: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/utils/isomorphic/ariaSnapshot.ts
     const name = this._readStringOrRegex() || undefined
-    const result: AriaTemplateRoleNode = {
-      kind: 'role',
-      role: role as AriaTemplateRoleNode['role'],
-      name,
-    }
+    const result: AriaTemplateRoleNode = { kind: 'role', role, name }
     this._readAttributes(result)
     this._skipWhitespace()
     if (!this._eof()) this._throwError('Unexpected input')

--- a/src/aria/folk/isomorphic/ariaSnapshot.ts
+++ b/src/aria/folk/isomorphic/ariaSnapshot.ts
@@ -505,8 +505,8 @@ export class KeyParser {
     this._throwError('Unterminated string')
   }
 
-  private _throwError(message: string, offset: number = 0): never {
-    throw new ParserError(message, offset || this._pos)
+  private _throwError(message: string, offset?: number): never {
+    throw new ParserError(message, offset ?? this._pos)
   }
 
   private _readRegex(): AriaRegex {
@@ -583,7 +583,14 @@ export class KeyParser {
   _parse(): AriaTemplateRoleNode {
     this._skipWhitespace()
 
-    const role = this._readIdentifier('role') as AriaTemplateRoleNode['role']
+    const roleStart = this._pos
+    const role = this._readIdentifier('role')
+    if (role === 'fragment') {
+      this._throwError(
+        'Role "fragment" is reserved for the internal root wrapper',
+        roleStart
+      )
+    }
     this._skipWhitespace()
     // DIVERGENCE(playwright): upstream uses `|| ''`, which makes
     // `- heading [level=1]` produce name="" instead of name=undefined.
@@ -591,7 +598,11 @@ export class KeyParser {
     // (falsy), causing asymmetry between matching and rendering.
     // Upstream: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/utils/isomorphic/ariaSnapshot.ts
     const name = this._readStringOrRegex() || undefined
-    const result: AriaTemplateRoleNode = { kind: 'role', role, name }
+    const result: AriaTemplateRoleNode = {
+      kind: 'role',
+      role: role as AriaTemplateRoleNode['role'],
+      name,
+    }
     this._readAttributes(result)
     this._skipWhitespace()
     if (!this._eof()) this._throwError('Unexpected input')

--- a/src/aria/folk/isomorphic/ariaSnapshot.ts
+++ b/src/aria/folk/isomorphic/ariaSnapshot.ts
@@ -505,8 +505,8 @@ export class KeyParser {
     this._throwError('Unterminated string')
   }
 
-  private _throwError(message: string, offset: number = this._pos): never {
-    throw new ParserError(message, offset)
+  private _throwError(message: string, offset: number = 0): never {
+    throw new ParserError(message, offset || this._pos)
   }
 
   private _readRegex(): AriaRegex {

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -120,11 +120,19 @@ export function matchAriaTree(
   // decides pass/fail (via matchesNode); mergeNode below it is purely
   // rendering. Wrapping in single-element lists ensures that contract
   // holds from the top level down.
-  const result = mergeChildLists([root], [template], '')
+  const rootContainerMode =
+    template.kind === 'role' && template.role === 'fragment'
+      ? template.containerMode
+      : undefined
+  const result = mergeChildLists([root], [template], '', rootContainerMode)
+  const resolved = result.resolved
+  if (result.pass && rootContainerMode && rootContainerMode !== 'contain') {
+    resolved.unshift(`- /children: ${rootContainerMode}`)
+  }
 
   return {
     pass: result.pass,
-    resolved: result.resolved.join('\n'),
+    resolved: resolved.join('\n'),
   }
 }
 

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -125,14 +125,13 @@ export function matchAriaTree(
       ? template.containerMode
       : undefined
   const result = mergeChildLists([root], [template], '', rootContainerMode)
-  const resolved = result.resolved
   if (result.pass && rootContainerMode && rootContainerMode !== 'contain') {
-    resolved.unshift(`- /children: ${rootContainerMode}`)
+    result.resolved.unshift(`- /children: ${rootContainerMode}`)
   }
 
   return {
     pass: result.pass,
-    resolved: resolved.join('\n'),
+    resolved: result.resolved.join('\n'),
   }
 }
 

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -115,22 +115,33 @@ export function matchAriaTree(
   // Normalize synthetic root fragments before entering the recursive merge.
   // The template root fragment may own /children metadata, so lift its
   // containerMode before unwrapping it into template roots.
-  const templateIsRootFragment =
-    template.kind === 'role' && template.role === 'fragment'
-  const rootContainerMode = templateIsRootFragment
+  const normalizedRoot = root.role === 'fragment' ? root.children : [root]
+  const normalizedTemplate = isAriaTemplateFragement(template)
+    ? (template.children ?? [])
+    : [template]
+  const containerMode = isAriaTemplateFragement(template)
     ? template.containerMode
     : undefined
-  const actualRoots = root.role === 'fragment' ? root.children : [root]
-  const templateRoots = templateIsRootFragment ? template.children || [] : [template]
-  const result = mergeChildLists(actualRoots, templateRoots, '', rootContainerMode)
-  if (result.pass && rootContainerMode && rootContainerMode !== 'contain') {
-    result.resolved.unshift(`- /children: ${rootContainerMode}`)
+  const result = mergeChildLists(
+    normalizedRoot,
+    normalizedTemplate,
+    '',
+    containerMode
+  )
+  if (result.pass && containerMode && containerMode !== 'contain') {
+    result.resolved.unshift(`- /children: ${containerMode}`)
   }
 
   return {
     pass: result.pass,
     resolved: result.resolved.join('\n'),
   }
+}
+
+function isAriaTemplateFragement(
+  template: AriaTemplateNode
+): template is AriaTemplateRoleNode {
+  return template.kind === 'role' && template.role === 'fragment'
 }
 
 // ---------------------------------------------------------------------------
@@ -251,7 +262,7 @@ function mergeChildLists(
 ): MergeResult {
   if (
     children.some((c) => typeof c !== 'string' && c.role === 'fragment') ||
-    templates.some((t) => t.kind === 'role' && t.role === 'fragment')
+    templates.some((t) => isAriaTemplateFragement(t))
   ) {
     throw new Error(
       'Internal error: fragment wrappers must be unwrapped at matchAriaTree root'

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -22,9 +22,10 @@ import { formatTextValue, formatNameValue } from './template'
 //   through the template's lens but has no say in pass/fail (returns string[],
 //   not a boolean). This separation works because matchesNode already
 //   traverses the full subtree; re-checking at the node level would be
-//   redundant. The entry point (matchAriaTree) wraps root and template in
-//   single-element lists so that mergeChildLists — and its pass/fail
-//   authority — is always the top-level driver.
+//   redundant. The entry point (matchAriaTree) first normalizes the root pair
+//   into a top-level list merge, preserving fragment wrapper /children mode,
+//   so mergeChildLists — and its pass/fail authority — is always the top-level
+//   driver.
 //
 // folk's renderNodeLines is used for actual-side rendering. Only the merge
 // assembly and template rendering (which Playwright doesn't need) are
@@ -42,13 +43,13 @@ import { formatTextValue, formatNameValue } from './template'
 //   Playwright takes a different approach: instead of flattening, it treats
 //   fragment as a wildcard role (matches any node) and relies on the entry
 //   point to walk root.children directly. Both are equally sound because
-//   fragment nodes never carry meaningful attributes or containerMode in
-//   practice — the parser only sets containerMode on top-level fragments,
-//   then unwraps single-child ones, so surviving fragments always have
-//   multiple children whose list semantics our flatten preserves correctly.
-//   The tradeoff is decomposition: Playwright keeps all match semantics in
-//   matchesNode; we split fragment handling into mergeChildLists, which is
-//   natural since we need that function anyway for three-way merge.
+//   fragment nodes never carry meaningful attributes in practice. The only
+//   semantic fragment wrapper we preserve is the parser-created top-level
+//   fragment's containerMode; mergeRoot carries that mode into the top-level
+//   list merge before mergeChildLists flattens the wrapper. The tradeoff is
+//   decomposition: Playwright keeps all match semantics in matchesNode; we
+//   split fragment handling into mergeRoot + mergeChildLists, which is natural
+//   since we need list-level control anyway for three-way merge.
 //   See: vendor/playwright/packages/injected/src/ariaSnapshot.ts
 //   (matchesNode, matchesNodeDeep)
 //
@@ -115,12 +116,20 @@ export function matchAriaTree(
   root: AriaNode,
   template: AriaTemplateNode
 ): MatchAriaResult {
-  // Enter through mergeChildLists — this is intentional, not just for
-  // fragment normalization. mergeChildLists is the only function that
-  // decides pass/fail (via matchesNode); mergeNode below it is purely
-  // rendering. Wrapping in single-element lists ensures that contract
-  // holds from the top level down.
-  const result = mergeChildLists([root], [template], '')
+  // Enter through mergeRoot/mergeChildLists — this is intentional, not just
+  // for fragment normalization. mergeChildLists is the only function that
+  // decides pass/fail (via matchesNode); mergeRoot exists only to preserve
+  // top-level fragment wrapper semantics while converting the root pair into
+  // the initial child-list merge problem. mergeNode below that is purely
+  // rendering.
+  const result = mergeChildLists(
+    [root],
+    [template],
+    '',
+    template.kind === 'role' && template.role === 'fragment'
+      ? template.containerMode
+      : undefined
+  )
 
   return {
     pass: result.pass,

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -22,10 +22,9 @@ import { formatTextValue, formatNameValue } from './template'
 //   through the template's lens but has no say in pass/fail (returns string[],
 //   not a boolean). This separation works because matchesNode already
 //   traverses the full subtree; re-checking at the node level would be
-//   redundant. The entry point (matchAriaTree) first normalizes the root pair
-//   into a top-level list merge, preserving fragment wrapper /children mode,
-//   so mergeChildLists — and its pass/fail authority — is always the top-level
-//   driver.
+//   redundant. The entry point (matchAriaTree) first converts the root into
+//   the initial child-list merge problem, so mergeChildLists — and its
+//   pass/fail authority — is always the top-level driver.
 //
 // folk's renderNodeLines is used for actual-side rendering. Only the merge
 // assembly and template rendering (which Playwright doesn't need) are
@@ -37,19 +36,18 @@ import { formatTextValue, formatNameValue } from './template'
 //   captureAriaTree always returns a fragment root; parseAriaTemplate may
 //   or may not (it unwraps single-child fragments, following Playwright).
 //
-//   We normalize by flattening: fragment = its children. This happens
-//   inside mergeChildLists so every recursion level handles it uniformly.
+//   Fragment role semantics are transparent, but fragment container metadata
+//   is not. We therefore keep fragments through matching/merging and strip
+//   only the rendered fragment shell in mergeNode. This lets a root-level
+//   /children directive behave like the same directive below any rendered
+//   role node.
 //
 //   Playwright takes a different approach: instead of flattening, it treats
 //   fragment as a wildcard role (matches any node) and relies on the entry
 //   point to walk root.children directly. Both are equally sound because
 //   fragment nodes never carry meaningful attributes in practice. The only
 //   semantic fragment wrapper we preserve is the parser-created top-level
-//   fragment's containerMode; mergeRoot carries that mode into the top-level
-//   list merge before mergeChildLists flattens the wrapper. The tradeoff is
-//   decomposition: Playwright keeps all match semantics in matchesNode; we
-//   split fragment handling into mergeRoot + mergeChildLists, which is natural
-//   since we need list-level control anyway for three-way merge.
+//   fragment's containerMode.
 //   See: vendor/playwright/packages/injected/src/ariaSnapshot.ts
 //   (matchesNode, matchesNodeDeep)
 //
@@ -116,20 +114,26 @@ export function matchAriaTree(
   root: AriaNode,
   template: AriaTemplateNode
 ): MatchAriaResult {
-  // Enter through mergeRoot/mergeChildLists — this is intentional, not just
-  // for fragment normalization. mergeChildLists is the only function that
-  // decides pass/fail (via matchesNode); mergeRoot exists only to preserve
-  // top-level fragment wrapper semantics while converting the root pair into
-  // the initial child-list merge problem. mergeNode below that is purely
-  // rendering.
-  const result = mergeChildLists(
-    [root],
-    [template],
-    '',
+  // The captured root is usually a synthetic fragment; snapshots target its
+  // rendered children, not the fragment shell.
+  //
+  // A parser-created template fragment is also invisible, but it can own
+  // root-level /children metadata. Only that root wrapper-fragment case uses
+  // mergeContainer: it merges the two root child lists while preserving the
+  // wrapper's renderable metadata. Otherwise, match the single template node
+  // against the captured root children, preserving the usual `- button`
+  // ergonomics.
+  const actualRoots = root.role === 'fragment' ? root.children : [root]
+  const result =
     template.kind === 'role' && template.role === 'fragment'
-      ? template.containerMode
-      : undefined
-  )
+      ? mergeContainer(
+          actualRoots,
+          template.children || [],
+          '',
+          template.containerMode,
+          template.containerMode
+        )
+      : mergeChildLists(actualRoots, [template], '')
 
   return {
     pass: result.pass,
@@ -241,6 +245,10 @@ function renderChildLines(child: AriaNode | string, indent: string): string[] {
   const lines: string[] = []
   if (typeof child === 'string') {
     lines.push(`${indent}- text: ${child}`)
+  } else if (child.role === 'fragment') {
+    for (const fragmentChild of child.children) {
+      lines.push(...renderChildLines(fragmentChild, indent))
+    }
   } else {
     renderNodeLines(child, indent, lines)
   }
@@ -253,14 +261,6 @@ function mergeChildLists(
   indent: string,
   containerMode?: ContainerMode
 ): MergeResult {
-  // fragment = its children (a fragment has no semantics of its own)
-  children = children.flatMap((c) =>
-    typeof c !== 'string' && c.role === 'fragment' ? c.children : [c]
-  )
-  templates = templates.flatMap((t) =>
-    t.kind === 'role' && t.role === 'fragment' ? t.children || [] : [t]
-  )
-
   if (containerMode === 'equal' || containerMode === 'deep-equal') {
     return mergeChildListsEqual(
       children,
@@ -334,6 +334,22 @@ function mergeChildListsEqual(
   return { resolved, pass: allPositionalMatched }
 }
 
+function mergeContainer(
+  children: (AriaNode | string)[],
+  templates: AriaTemplateNode[],
+  indent: string,
+  containerMode?: ContainerMode,
+  directiveMode?: ContainerMode
+): MergeResult {
+  const childResult = mergeChildLists(children, templates, indent, containerMode)
+  const resolved: string[] = []
+  if (directiveMode && directiveMode !== 'contain') {
+    resolved.push(`${indent}- /children: ${directiveMode}`)
+  }
+  resolved.push(...childResult.resolved)
+  return { resolved, pass: childResult.pass }
+}
+
 /** Render a single actual node through the template's lens.
  *
  *  Intentionally returns only resolved lines, not pass/fail. This is
@@ -360,6 +376,21 @@ function mergeNode(
   // One text node and the other not
   if (typeof node === 'string' || template.kind === 'text') {
     return renderChildLines(node, indent)
+  }
+
+  if (template.role === 'fragment' && node.role === 'fragment') {
+    // A template fragment here is the parser-created root wrapper, not a
+    // user-visible ARIA role. matchAriaTree pairs it with the captured root
+    // fragment so root-level /children metadata has an owner during rendering.
+    // Render that wrapper as an invisible child-list container: preserve its
+    // /children metadata, but omit a role key/shell.
+    return mergeContainer(
+      node.children,
+      template.children || [],
+      indent,
+      template.containerMode ?? (isDeepEqual ? 'equal' : 'contain'),
+      template.containerMode
+    ).resolved
   }
 
   // Resolved key (e.g. `- heading "Hello" [level=1]`):

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -36,19 +36,16 @@ import { formatTextValue, formatNameValue } from './template'
 //   captureAriaTree always returns a fragment root; parseAriaTemplate may
 //   or may not (it unwraps single-child fragments, following Playwright).
 //
-//   We normalize by flattening: fragment = its children. This happens
-//   inside mergeChildLists so every recursion level handles it uniformly.
+//   We normalize these synthetic root wrappers in matchAriaTree before
+//   entering the recursive merge. User-authored `fragment` template roles are
+//   rejected by the parser, so mergeChildLists never needs general fragment
+//   semantics.
 //
 //   Playwright takes a different approach: instead of flattening, it treats
 //   fragment as a wildcard role (matches any node) and relies on the entry
-//   point to walk root.children directly. Both are equally sound because
-//   fragment nodes never carry meaningful attributes or containerMode in
-//   practice — the parser only sets containerMode on top-level fragments,
-//   then unwraps single-child ones, so surviving fragments always have
-//   multiple children whose list semantics our flatten preserves correctly.
-//   The tradeoff is decomposition: Playwright keeps all match semantics in
-//   matchesNode; we split fragment handling into mergeChildLists, which is
-//   natural since we need that function anyway for three-way merge.
+//   point to walk root.children directly. Our root normalization follows the
+//   same boundary idea while keeping three-way merge decisions in
+//   mergeChildLists.
 //   See: vendor/playwright/packages/injected/src/ariaSnapshot.ts
 //   (matchesNode, matchesNodeDeep)
 //
@@ -115,16 +112,17 @@ export function matchAriaTree(
   root: AriaNode,
   template: AriaTemplateNode
 ): MatchAriaResult {
-  // Enter through mergeChildLists — this is intentional, not just for
-  // fragment normalization. mergeChildLists is the only function that
-  // decides pass/fail (via matchesNode); mergeNode below it is purely
-  // rendering. Wrapping in single-element lists ensures that contract
-  // holds from the top level down.
-  const rootContainerMode =
+  // Normalize synthetic root fragments before entering the recursive merge.
+  // The template root fragment may own /children metadata, so lift its
+  // containerMode before unwrapping it into template roots.
+  const templateIsRootFragment =
     template.kind === 'role' && template.role === 'fragment'
-      ? template.containerMode
-      : undefined
-  const result = mergeChildLists([root], [template], '', rootContainerMode)
+  const rootContainerMode = templateIsRootFragment
+    ? template.containerMode
+    : undefined
+  const actualRoots = root.role === 'fragment' ? root.children : [root]
+  const templateRoots = templateIsRootFragment ? template.children || [] : [template]
+  const result = mergeChildLists(actualRoots, templateRoots, '', rootContainerMode)
   if (result.pass && rootContainerMode && rootContainerMode !== 'contain') {
     result.resolved.unshift(`- /children: ${rootContainerMode}`)
   }
@@ -251,13 +249,14 @@ function mergeChildLists(
   indent: string,
   containerMode?: ContainerMode
 ): MergeResult {
-  // fragment = its children (a fragment has no semantics of its own)
-  children = children.flatMap((c) =>
-    typeof c !== 'string' && c.role === 'fragment' ? c.children : [c]
-  )
-  templates = templates.flatMap((t) =>
-    t.kind === 'role' && t.role === 'fragment' ? t.children || [] : [t]
-  )
+  if (
+    children.some((c) => typeof c !== 'string' && c.role === 'fragment') ||
+    templates.some((t) => t.kind === 'role' && t.role === 'fragment')
+  ) {
+    throw new Error(
+      'Internal error: fragment wrappers must be unwrapped at matchAriaTree root'
+    )
+  }
 
   if (containerMode === 'equal' || containerMode === 'deep-equal') {
     return mergeChildListsEqual(

--- a/src/aria/match.ts
+++ b/src/aria/match.ts
@@ -22,9 +22,9 @@ import { formatTextValue, formatNameValue } from './template'
 //   through the template's lens but has no say in pass/fail (returns string[],
 //   not a boolean). This separation works because matchesNode already
 //   traverses the full subtree; re-checking at the node level would be
-//   redundant. The entry point (matchAriaTree) first converts the root into
-//   the initial child-list merge problem, so mergeChildLists — and its
-//   pass/fail authority — is always the top-level driver.
+//   redundant. The entry point (matchAriaTree) wraps root and template in
+//   single-element lists so that mergeChildLists — and its pass/fail
+//   authority — is always the top-level driver.
 //
 // folk's renderNodeLines is used for actual-side rendering. Only the merge
 // assembly and template rendering (which Playwright doesn't need) are
@@ -36,18 +36,19 @@ import { formatTextValue, formatNameValue } from './template'
 //   captureAriaTree always returns a fragment root; parseAriaTemplate may
 //   or may not (it unwraps single-child fragments, following Playwright).
 //
-//   Fragment role semantics are transparent, but fragment container metadata
-//   is not. We therefore keep fragments through matching/merging and strip
-//   only the rendered fragment shell in mergeNode. This lets a root-level
-//   /children directive behave like the same directive below any rendered
-//   role node.
+//   We normalize by flattening: fragment = its children. This happens
+//   inside mergeChildLists so every recursion level handles it uniformly.
 //
 //   Playwright takes a different approach: instead of flattening, it treats
 //   fragment as a wildcard role (matches any node) and relies on the entry
 //   point to walk root.children directly. Both are equally sound because
-//   fragment nodes never carry meaningful attributes in practice. The only
-//   semantic fragment wrapper we preserve is the parser-created top-level
-//   fragment's containerMode.
+//   fragment nodes never carry meaningful attributes or containerMode in
+//   practice — the parser only sets containerMode on top-level fragments,
+//   then unwraps single-child ones, so surviving fragments always have
+//   multiple children whose list semantics our flatten preserves correctly.
+//   The tradeoff is decomposition: Playwright keeps all match semantics in
+//   matchesNode; we split fragment handling into mergeChildLists, which is
+//   natural since we need that function anyway for three-way merge.
 //   See: vendor/playwright/packages/injected/src/ariaSnapshot.ts
 //   (matchesNode, matchesNodeDeep)
 //
@@ -114,26 +115,12 @@ export function matchAriaTree(
   root: AriaNode,
   template: AriaTemplateNode
 ): MatchAriaResult {
-  // The captured root is usually a synthetic fragment; snapshots target its
-  // rendered children, not the fragment shell.
-  //
-  // A parser-created template fragment is also invisible, but it can own
-  // root-level /children metadata. Only that root wrapper-fragment case uses
-  // mergeContainer: it merges the two root child lists while preserving the
-  // wrapper's renderable metadata. Otherwise, match the single template node
-  // against the captured root children, preserving the usual `- button`
-  // ergonomics.
-  const actualRoots = root.role === 'fragment' ? root.children : [root]
-  const result =
-    template.kind === 'role' && template.role === 'fragment'
-      ? mergeContainer(
-          actualRoots,
-          template.children || [],
-          '',
-          template.containerMode,
-          template.containerMode
-        )
-      : mergeChildLists(actualRoots, [template], '')
+  // Enter through mergeChildLists — this is intentional, not just for
+  // fragment normalization. mergeChildLists is the only function that
+  // decides pass/fail (via matchesNode); mergeNode below it is purely
+  // rendering. Wrapping in single-element lists ensures that contract
+  // holds from the top level down.
+  const result = mergeChildLists([root], [template], '')
 
   return {
     pass: result.pass,
@@ -245,10 +232,6 @@ function renderChildLines(child: AriaNode | string, indent: string): string[] {
   const lines: string[] = []
   if (typeof child === 'string') {
     lines.push(`${indent}- text: ${child}`)
-  } else if (child.role === 'fragment') {
-    for (const fragmentChild of child.children) {
-      lines.push(...renderChildLines(fragmentChild, indent))
-    }
   } else {
     renderNodeLines(child, indent, lines)
   }
@@ -261,6 +244,14 @@ function mergeChildLists(
   indent: string,
   containerMode?: ContainerMode
 ): MergeResult {
+  // fragment = its children (a fragment has no semantics of its own)
+  children = children.flatMap((c) =>
+    typeof c !== 'string' && c.role === 'fragment' ? c.children : [c]
+  )
+  templates = templates.flatMap((t) =>
+    t.kind === 'role' && t.role === 'fragment' ? t.children || [] : [t]
+  )
+
   if (containerMode === 'equal' || containerMode === 'deep-equal') {
     return mergeChildListsEqual(
       children,
@@ -334,22 +325,6 @@ function mergeChildListsEqual(
   return { resolved, pass: allPositionalMatched }
 }
 
-function mergeContainer(
-  children: (AriaNode | string)[],
-  templates: AriaTemplateNode[],
-  indent: string,
-  containerMode?: ContainerMode,
-  directiveMode?: ContainerMode
-): MergeResult {
-  const childResult = mergeChildLists(children, templates, indent, containerMode)
-  const resolved: string[] = []
-  if (directiveMode && directiveMode !== 'contain') {
-    resolved.push(`${indent}- /children: ${directiveMode}`)
-  }
-  resolved.push(...childResult.resolved)
-  return { resolved, pass: childResult.pass }
-}
-
 /** Render a single actual node through the template's lens.
  *
  *  Intentionally returns only resolved lines, not pass/fail. This is
@@ -376,21 +351,6 @@ function mergeNode(
   // One text node and the other not
   if (typeof node === 'string' || template.kind === 'text') {
     return renderChildLines(node, indent)
-  }
-
-  if (template.role === 'fragment' && node.role === 'fragment') {
-    // A template fragment here is the parser-created root wrapper, not a
-    // user-visible ARIA role. matchAriaTree pairs it with the captured root
-    // fragment so root-level /children metadata has an owner during rendering.
-    // Render that wrapper as an invisible child-list container: preserve its
-    // /children metadata, but omit a role key/shell.
-    return mergeContainer(
-      node.children,
-      template.children || [],
-      indent,
-      template.containerMode ?? (isDeepEqual ? 'equal' : 'contain'),
-      template.containerMode
-    ).resolved
   }
 
   // Resolved key (e.g. `- heading "Hello" [level=1]`):

--- a/src/aria/template.ts
+++ b/src/aria/template.ts
@@ -30,6 +30,9 @@ export function renderAriaTemplate(template: AriaTemplateNode): string {
   if (template.kind === 'text') {
     lines.push(`- text: ${formatTextValue(template.text)}`)
   } else if (template.role === 'fragment') {
+    if (template.containerMode && template.containerMode !== 'contain') {
+      lines.push(`- /children: ${template.containerMode}`)
+    }
     for (const child of template.children || [])
       renderTemplateLines(child, '', lines)
   } else {

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4512,6 +4512,63 @@ describe('/children directive', () => {
     `)
   })
 
+  test('/children: deep-equal at root - fail', () => {
+    const html = `
+      <ul>
+        <li>A</li>
+        <li>B</li>
+      </ul>
+    `
+    const template = `
+      - /children: deep-equal
+      - list:
+        - listitem: a
+    `
+    expect(match(html, template)).toMatchInlineSnapshot(`
+      {
+        "actual": "
+      - list:
+        - listitem: A
+        - listitem: B
+      ",
+        "actualResolved": "
+      - list:
+        - listitem: A
+        - listitem: B
+      ",
+        "expected": "
+      - /children: deep-equal
+      - list:
+        - listitem: a
+      ",
+        "pass": false,
+      }
+    `)
+  })
+
+  test('/children: deep-equal at root - pass', () => {
+    const html = `
+      <div></div>
+    `
+    const template = `
+      - /children: deep-equal
+    `
+    expect(match(html, template)).toMatchInlineSnapshot(`
+      {
+        "actual": "
+
+      ",
+        "actualResolved": "
+      - /children: deep-equal
+      ",
+        "expected": "
+      - /children: deep-equal
+      ",
+        "pass": true,
+      }
+    `)
+  })
+
   test('/children: equal at non root', () => {
     const html = `
       <main>

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4444,25 +4444,20 @@ describe('/children directive', () => {
     `)
   })
 
-  // TODO
-  test('/children: equal at root — partial update drops directive from resolved', () => {
+  // TODO: partial update drops /children directive at root
+  test('/children: equal at root', () => {
     const html = `
       <ul>
         <li>a</li>
         <li>b</li>
       </ul>
     `
-    expect(
-      match(
-        html,
-        `
-        - /children: equal
-        - list:
-          - listitem: a
-      `
-        //  { assertInvariant: true }
-      )
-    ).toMatchInlineSnapshot(`
+    const template = `
+      - /children: equal
+      - list:
+        - listitem: a
+    `
+    expect(match(html, template)).toMatchInlineSnapshot(`
       {
         "actual": "
       - list:

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4478,6 +4478,46 @@ describe('/children directive', () => {
     `)
   })
 
+  test('/children: equal at non root', () => {
+    const html = `
+      <main>
+        <ul>
+          <li>a</li>
+          <li>b</li>
+        </ul>
+      </main>
+    `
+    const template = `
+      - main:
+        - /children: equal
+        - list:
+          - listitem: a
+    `
+    expect(match(html, template)).toMatchInlineSnapshot(`
+      {
+        "actual": "
+      - main:
+        - list:
+          - listitem: a
+          - listitem: b
+      ",
+        "actualResolved": "
+      - main:
+        - /children: equal
+        - list:
+          - listitem: a
+      ",
+        "expected": "
+      - main:
+        - /children: equal
+        - list:
+          - listitem: a
+      ",
+        "pass": true,
+      }
+    `)
+  })
+
   test('/children: equal — resolved preserves directive on matched branch, purges on failed', () => {
     // Two sibling lists both with /children: equal.
     // First list matches exactly → directive preserved in resolved.

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -2537,6 +2537,40 @@ describe('parseAriaTemplate', () => {
     )
   })
 
+  test('unknown alphabetic role is accepted', () => {
+    expect(parseAriaTemplate('- madeuprole')).toMatchInlineSnapshot(`
+      {
+        "kind": "role",
+        "name": undefined,
+        "role": "madeuprole",
+      }
+    `)
+  })
+
+  test('explicit fragment role is rejected', () => {
+    expect(() => parseAriaTemplate('- fragment'))
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: Role "fragment" is reserved for the internal root wrapper:
+
+      fragment
+      ^
+      ]
+    `)
+    expect(() =>
+      parseAriaTemplate(`
+      - main:
+        - fragment:
+          - button
+    `)
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Role "fragment" is reserved for the internal root wrapper:
+
+      fragment
+      ^
+      ]
+    `)
+  })
+
   // Block scalars (|) are not supported by the minimal YAML parser.
   test('YAML block scalar (| multiline) is not supported', () => {
     expect(() =>
@@ -4444,7 +4478,6 @@ describe('/children directive', () => {
     `)
   })
 
-  // TODO: partial update drops /children directive at root
   test('/children: equal at root', () => {
     const html = `
       <ul>
@@ -4465,6 +4498,7 @@ describe('/children directive', () => {
         - listitem: b
       ",
         "actualResolved": "
+      - /children: equal
       - list:
         - listitem: a
       ",

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -4385,6 +4385,45 @@ describe('/children directive', () => {
     `)
   })
 
+  // TODO
+  test('/children: equal at root — partial update drops directive from resolved', () => {
+    const html = `
+      <ul>
+        <li>a</li>
+        <li>b</li>
+      </ul>
+    `
+    expect(
+      match(
+        html,
+        `
+        - /children: equal
+        - list:
+          - listitem: a
+      `
+        //  { assertInvariant: true }
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "actual": "
+      - list:
+        - listitem: a
+        - listitem: b
+      ",
+        "actualResolved": "
+      - list:
+        - listitem: a
+      ",
+        "expected": "
+      - /children: equal
+      - list:
+        - listitem: a
+      ",
+        "pass": true,
+      }
+    `)
+  })
+
   test('/children: equal — resolved preserves directive on matched branch, purges on failed', () => {
     // Two sibling lists both with /children: equal.
     // First list matches exactly → directive preserved in resolved.
@@ -4487,12 +4526,15 @@ describe('/children directive', () => {
 
   test('renderAriaTemplate preserves /children directive', () => {
     const t = parseAriaTemplate(`
+      - /children: equal
       - list:
         - /children: equal
         - listitem: A
     `)
-    expect(renderAriaTemplate(t)).toMatchInlineSnapshot(`
-      "- list:
+    expect('\n' + renderAriaTemplate(t)).toMatchInlineSnapshot(`
+      "
+      - /children: equal
+      - list:
         - /children: equal
         - listitem: A"
     `)

--- a/test/aria.test.ts
+++ b/test/aria.test.ts
@@ -2550,12 +2550,12 @@ describe('parseAriaTemplate', () => {
   test('explicit fragment role is rejected', () => {
     expect(() => parseAriaTemplate('- fragment'))
       .toThrowErrorMatchingInlineSnapshot(`
-      [Error: Role "fragment" is reserved for the internal root wrapper:
+        [Error: Invalid role "fragment":
 
-      fragment
-      ^
-      ]
-    `)
+        fragment
+                ^
+        ]
+      `)
     expect(() =>
       parseAriaTemplate(`
       - main:
@@ -2563,10 +2563,10 @@ describe('parseAriaTemplate', () => {
           - button
     `)
     ).toThrowErrorMatchingInlineSnapshot(`
-      [Error: Role "fragment" is reserved for the internal root wrapper:
+      [Error: Invalid role "fragment":
 
       fragment
-      ^
+              ^
       ]
     `)
   })


### PR DESCRIPTION
- Related https://github.com/vitest-dev/vitest/issues/10158
- Closes https://github.com/vitest-dev/ivya/pull/14 (supersedes)

This PR fixes root-level `/children` directives on ARIA templates. Previously, the matcher outright ignored `containerMode` on the root template fragment, so root `/children: equal` and `/children: deep-equal` behaved like default contain matching.

The fix treats `fragment` as an internal root wrapper. `matchAriaTree` now lifts the root wrapper’s `containerMode` before unwrapping synthetic actual/template fragments, then passes that mode into the top-level child-list merge. When the match passes, the root directive is restored into `resolved`; when it fails, it is dropped consistently with existing failed-branch directive behavior.

To keep this model explicit, YAML-authored `fragment` roles are rejected and recursive matching asserts that fragment wrappers have already been unwrapped at the root boundary.